### PR TITLE
Version name from git tag

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,7 +12,7 @@ android {
         minSdkVersion 16
         targetSdkVersion 25
         versionCode 115
-        versionName "1.1.5"
+        versionName getVersionName()
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
 
@@ -98,6 +98,15 @@ dependencyUpdates.resolutionStrategy = {
             }
         }
     }
+}
+
+def getVersionName = { ->
+    def stdout = new ByteArrayOutputStream()
+    exec {
+        commandLine 'git', 'describe', '--tags'
+        standardOutput = stdout
+    }
+    return stdout.toString().trim()
 }
 
 apply plugin: 'com.google.gms.google-services'


### PR DESCRIPTION
We had more than 3 Continous integrations. Moved to one. And take version code from git tag. Read more over here http://docs.buddybuild.com/docs/android-auto-versioning